### PR TITLE
Upgrade to sauce-connect 4.5.1

### DIFF
--- a/sauce-connect.rb
+++ b/sauce-connect.rb
@@ -3,8 +3,8 @@ require "formula"
 
 class SauceConnect < Formula
   homepage "https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy"
-  url "https://saucelabs.com/downloads/sc-4.4.9-osx.zip"
-  sha256 "c88731ffe03c1f0c7ff98e0036a467ea5bce1ff757b27b31c85d6e6e219cdfc5"
+  url "https://saucelabs.com/downloads/sc-4.5.1-osx.zip"
+  sha256 "920ae7bd5657bccdcd27bb596593588654a2820486043e9a12c9062700697e66"
 
   def install
     bin.install 'bin/sc'


### PR DESCRIPTION
@stabbylambda I installed this manually. Works for me. Let me know if I did this right.

Got the sha256 from:
```
> $ openssl sha256 < sc-4.5.1-osx.zip
920ae7bd5657bccdcd27bb596593588654a2820486043e9a12c9062700697e66
```