### PR TITLE
Upgrade to sauce-connect 4.5.3

### DIFF
--- a/sauce-connect.rb
+++ b/sauce-connect.rb
@@ -3,8 +3,8 @@ require "formula"
 
 class SauceConnect < Formula
   homepage "https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy"
-  url "https://saucelabs.com/downloads/sc-4.5.1-osx.zip"
-  sha256 "920ae7bd5657bccdcd27bb596593588654a2820486043e9a12c9062700697e66"
+  url "https://saucelabs.com/downloads/sc-4.5.3-osx.zip"
+  sha256 "838d869fbf96ba6595fda2fa40008326337d419e1891a43fee826b995515d4bf"
 
   def install
     bin.install 'bin/sc'


### PR DESCRIPTION
Hey @stabbylambda, I believe this change brings in the latest version of sauce-connect.

```Shell
> openssl sha256 < sc-4.5.3-osx.zip
838d869fbf96ba6595fda2fa40008326337d419e1891a43fee826b995515d4bf
```